### PR TITLE
UTF-8 is recommended to be specified in unicode method. 

### DIFF
--- a/sidebar/SideBarGit.py
+++ b/sidebar/SideBarGit.py
@@ -222,7 +222,7 @@ class SideBarGit:
 				try:
 					content += stdout
 				except:
-					content += unicode(stdout, errors='ignore')
+					content += unicode(stdout, 'UTF-8', errors='ignore')
 
 				edit = view.begin_edit()
 				view.replace(edit, sublime.Region(0, view.size()), content);


### PR DESCRIPTION
Because the message including Japanese (maybe also not ASCII character) were hidden, UTF-8 is recommended to be specified. 
