### PR TITLE
Show just the branch name (remove previous commit) when displaying git branches in quick panel

### DIFF
--- a/SideBarGitCommands.py
+++ b/SideBarGitCommands.py
@@ -1078,7 +1078,7 @@ class SideBarGitBranchSwitchToCommand(sublime_plugin.WindowCommand):
 		for repo in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 			object = Object()
 			object.item = repo.repository
-			object.command = ['git', 'branch', '-v']
+			object.command = ['git', 'branch']
 			object.silent = True
 			SideBarGit().run(object)
 			SideBarGit().quickPanel(self.on_done, repo.repository, (SideBarGit.last_stdout.decode('utf-8')).split('\n'))
@@ -1104,7 +1104,7 @@ class SideBarGitBranchDeleteCommand(sublime_plugin.WindowCommand):
 		for repo in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 			object = Object()
 			object.item = repo.repository
-			object.command = ['git', 'branch', '-v']
+			object.command = ['git', 'branch']
 			object.silent = True
 			SideBarGit().run(object)
 			SideBarGit().quickPanel(self.on_done, repo.repository, (SideBarGit.last_stdout.decode('utf-8')).split('\n'))
@@ -1130,7 +1130,7 @@ class SideBarGitBranchDeleteForceCommand(sublime_plugin.WindowCommand):
 		for repo in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 			object = Object()
 			object.item = repo.repository
-			object.command = ['git', 'branch', '-v']
+			object.command = ['git', 'branch']
 			object.silent = True
 			SideBarGit().run(object)
 			SideBarGit().quickPanel(self.on_done, repo.repository, (SideBarGit.last_stdout.decode('utf-8')).split('\n'))
@@ -1156,7 +1156,7 @@ class SideBarGitMergeToCurrentFromCommand(sublime_plugin.WindowCommand):
 		for repo in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 			object = Object()
 			object.item = repo.repository
-			object.command = ['git', 'branch', '-v']
+			object.command = ['git', 'branch']
 			object.silent = True
 			SideBarGit().run(object)
 			SideBarGit().quickPanel(self.on_done, repo.repository, (SideBarGit.last_stdout.decode('utf-8')).split('\n'))


### PR DESCRIPTION
I found that the branches don't display very well in the quick panel with the previous commit sha and description. I removed the -v from the `git branch -v` call, so it just shows the branch name.

Thanks!
