### PR TITLE
Better spliting for customized commands

### DIFF
--- a/SideBarGitCommands.py
+++ b/SideBarGitCommands.py
@@ -700,7 +700,7 @@ class SideBarGitPushWithOptionsCommand(sublime_plugin.WindowCommand):
 			for item in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 				object = Object()
 				object.item = item.repository
-				object.command = content.split(' ')
+				object.command = content.split()
 				object.to_status_bar = True
 				SideBarGit().run(object, True)
 
@@ -765,7 +765,7 @@ class SideBarGitPullWithOptionsCommand(sublime_plugin.WindowCommand):
 			for item in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 				object = Object()
 				object.item = item.repository
-				object.command = content.split(' ')
+				object.command = content.split()
 				SideBarGit().run(object, True)
 
 	def is_enabled(self, paths = []):
@@ -793,7 +793,7 @@ class SideBarGitFetchWithOptionsCommand(sublime_plugin.WindowCommand):
 			for item in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 				object = Object()
 				object.item = item.repository
-				object.command = content.split(' ')
+				object.command = content.split()
 				SideBarGit().run(object, True)
 
 	def is_enabled(self, paths = []):
@@ -998,7 +998,7 @@ class SideBarGitLiberalCommand(sublime_plugin.WindowCommand):
 			for item in SideBarSelection(paths).getSelectedDirectoriesOrDirnames():
 				object = Object()
 				object.item = item
-				object.command = content.split(' ')
+				object.command = content.split()
 				object.title = content
 				object.no_results = 'No output'
 				object.syntax_file = 'Packages/Diff/Diff.tmLanguage'
@@ -1016,7 +1016,7 @@ class SideBarGitRemoteAddCommand(sublime_plugin.WindowCommand):
 			for repo in SideBarGit().getSelectedRepos(SideBarSelection(paths).getSelectedItems()):
 				object = Object()
 				object.item = repo.repository
-				object.command = content.split(' ')
+				object.command = content.split()
 				object.to_status_bar = True
 				SideBarGit().run(object)
 


### PR DESCRIPTION
Note: `•` = whitespace, just for visualization here
## 

For example, when `"command": "side_bar_git_liberal"` is triggered, if we type `git••show`, the command is split into `['git', '', 'show']` which results in following screenshots.

![2016-01-10_09-51-00](https://cloud.githubusercontent.com/assets/6594915/12219468/b51f9eaa-b77f-11e5-97d2-a50bd6a4c16f.png) gives
![2016-01-10_09-41-18](https://cloud.githubusercontent.com/assets/6594915/12219454/1e3c0e88-b77f-11e5-93af-b7eb9b434e32.png)

Use `str.split()` to split a string with **consecutive** whitespaces.
Doc: https://docs.python.org/3/library/stdtypes.html?highlight=str.split#str.split
